### PR TITLE
Refactor specific docker image tests to push common behaviour to an interface/abstract class and inherit from it

### DIFF
--- a/src/main/java/DockerImage.java
+++ b/src/main/java/DockerImage.java
@@ -1,5 +1,6 @@
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public enum DockerImage {
@@ -105,6 +106,23 @@ public enum DockerImage {
     public String[] getEnvironmentVariables() {
         return this.environmentVariables;
     }
+
+    /**
+     * Returns the value of the specified environment variable if it is configured for this Docker image,
+     * else returns a null.
+     * @param name Name of the environment variable whose value is to be returned,
+     * @return The value of the environment variable, null if it isn't found.
+     */
+    public String getEnvironmentVariable(String name) {
+        Objects.requireNonNull(name);
+        String prefixToMatch = name + "=";
+        return Arrays.stream(environmentVariables)
+            .filter(environmentVariable -> environmentVariable.startsWith(prefixToMatch))
+            .map(environmentVariable -> environmentVariable.substring(prefixToMatch.length()))
+            .findFirst()
+            .orElse(null);
+    }
+
 
     @Override
     public String toString() {

--- a/src/test/java/ADockerImageTest.java
+++ b/src/test/java/ADockerImageTest.java
@@ -1,0 +1,53 @@
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public abstract class ADockerImageTest {
+
+    /**
+     * Returns a list of docker images to deploy as containers and test.
+     * @return A list of docker images to deploy as containers and test.
+     */
+    public abstract DockerImage[] getDockerImages();
+
+    /**
+     * Returns the name to use for the test container.
+     * @return The name to use for the test container.
+     */
+    public abstract String getContainerName();
+
+    /**
+     * Returns the time to wait for the container to start up in milliseconds.
+     * @return The time to wait for the container to start up in milliseconds.
+     */
+    public abstract long getStartupWaitTimeInMs();
+
+    /**
+     * Test the service running in the docker container.
+     * @param dockerImage Docker image that has been deployed to a container.
+     */
+    public abstract void testServiceInDockerContainer(DockerImage dockerImage);
+
+    /**
+     * Deploy and test the pre-specified list of docker images as containers.
+     * @throws InterruptedException If the container deployment is interrupted.
+     */
+    @Test
+    public void testDockerContainerDeployment() throws InterruptedException {
+        DockerImage[] dockerImages = getDockerImages();
+        for(DockerImage dockerImage:dockerImages) {
+            String containerName = getContainerName();
+            long startupWaitTimeInMs = getStartupWaitTimeInMs();
+            DockerUtility dockerUtility = new DockerUtility();
+            try {
+                // Create and run container
+                dockerUtility.createAndRunContainer(dockerImage, containerName, false);
+                // Wait for the container to start up
+                Thread.sleep(startupWaitTimeInMs);
+                // Test the service running in the container
+                Assertions.assertDoesNotThrow(() -> testServiceInDockerContainer(dockerImage));
+            } finally {
+                dockerUtility.removeContainerIfExists(containerName);
+            }
+        }
+    }
+}

--- a/src/test/java/ElasticsearchDockerImageTest.java
+++ b/src/test/java/ElasticsearchDockerImageTest.java
@@ -1,5 +1,5 @@
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Objects;
 
 import javax.ws.rs.HttpMethod;
 
@@ -14,54 +14,45 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
-public class ElasticsearchDockerImageTest {
+public class ElasticsearchDockerImageTest extends ADockerImageTest{
 
     private static final Logger logger = LogManager.getLogger(ElasticsearchDockerImageTest.class);
-    private static final RequestOptions COMMON_OPTIONS;
-    private static RestClient restClient = RestClient.builder(
+
+    @Override
+    public DockerImage[] getDockerImages() {
+        return new DockerImage[] {
+            DockerImage.ELASTICSEARCH_7_9_2
+        };
+    }
+
+    @Override
+    public String getContainerName() {
+        return "elastic_search_container";
+    }
+
+    @Override
+    public long getStartupWaitTimeInMs() {
+        return 30_000;
+    }
+
+    @Override
+    public void testServiceInDockerContainer(DockerImage dockerImage) {
+        final RequestOptions COMMON_OPTIONS;
+        RestClient restClient = RestClient.builder(
             new HttpHost("localhost", 9200, "http"),
-            new HttpHost("localhost", 9300, "http")).build();
-    static {
+            new HttpHost("localhost", 9300, "http")
+        ).build();
         RequestOptions.Builder builder = RequestOptions.DEFAULT.toBuilder();
         Base64 base64 = new Base64();
-        String userName = Arrays.stream(DockerImage.ELASTICSEARCH_7_9_2.getEnvironmentVariables())
-                .filter(environmentVariable -> environmentVariable.startsWith("ELASTIC_USERNAME="))
-                .map(environmentVariable -> environmentVariable.substring("ELASTIC_USERNAME=".length()))
-                .findFirst()
-                .orElse("");
-        String password = Arrays.stream(DockerImage.ELASTICSEARCH_7_9_2.getEnvironmentVariables())
-                .filter(environmentVariable -> environmentVariable.startsWith("ELASTIC_PASSWORD="))
-                .map(environmentVariable -> environmentVariable.substring("ELASTIC_PASSWORD=".length()))
-                .findFirst()
-                .orElse("");
+        String userName = dockerImage.getEnvironmentVariable("ELASTIC_USERNAME");
+        Objects.requireNonNull(userName);
+        String password = dockerImage.getEnvironmentVariable("ELASTIC_PASSWORD");
+        Objects.requireNonNull(password);
         String encoding = base64.encodeAsString((userName + ":" + password).getBytes());
         builder.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + encoding);
         COMMON_OPTIONS = builder.build();
-    }
 
-    @ParameterizedTest
-    @CsvSource(
-            "ELASTICSEARCH_7_9_2"
-    )
-    public void testElasticsearchDockerImage(DockerImage dockerImage) throws InterruptedException {
-        DockerUtility dockerUtility = new DockerUtility();
-        String containerName = "elasticsearch";
-        try {
-            // Create and run container
-            dockerUtility.createAndRunContainer(dockerImage, containerName, false);
-            // Wait 20s for the ES container to start up
-            Thread.sleep(20_000);
-            // Index and delete a test document
-            Assertions.assertDoesNotThrow(() -> connectToElasticsearch());
-        } finally {
-            dockerUtility.removeContainerIfExists(containerName);
-        }
-    }
-
-    private void connectToElasticsearch() {
         try {
             String testIndex = "test_index";
             Request insertRequest = new Request(HttpMethod.POST, "/" + testIndex + "/_doc");
@@ -78,6 +69,7 @@ public class ElasticsearchDockerImageTest {
             Assertions.assertEquals("OK", deleteResponse.getStatusLine().getReasonPhrase());
         } catch (IOException e) {
             logger.error("Something went wrong while connecting to Elasticsearch - " + e.getMessage(), e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/MongoDBDockerImageTest.java
+++ b/src/test/java/MongoDBDockerImageTest.java
@@ -1,62 +1,45 @@
 import com.mongodb.MongoClient;
 import com.mongodb.MongoCredential;
 import com.mongodb.ServerAddress;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
+import java.util.Objects;
 
-public class MongoDBDockerImageTest {
+import org.junit.jupiter.api.Assertions;
 
-    /**
-     * Connects to the specified MongoDB database.
-     * @param dockerImage Docker image to retrieve all connection parameters from
-     */
-    private void connectToMongoDBDatabase(DockerImage dockerImage) {
-        String password = Arrays.stream(dockerImage.getEnvironmentVariables())
-                .filter(environmentVariable -> environmentVariable.startsWith("MONGO_INITDB_ROOT_PASSWORD="))
-                .map(environmentVariable -> environmentVariable.substring(27))
-                .findFirst()
-                .orElse("");
+public class MongoDBDockerImageTest extends ADockerImageTest {
 
-        MongoCredential credential = MongoCredential.createCredential("root", "admin", password.toCharArray());
-        MongoClient mongoClient = new MongoClient(
-                new ServerAddress("localhost", 27017),
-                Collections.singletonList(credential)
-        );
-        Assertions.assertEquals(
-                3,
-                mongoClient.listDatabaseNames()
-                        .into(new ArrayList<>())
-                        .size()
-        );
+    @Override
+    public DockerImage[] getDockerImages() {
+        return new DockerImage[] {
+            DockerImage.MONGODB_LATEST
+        };
     }
 
-    @ParameterizedTest
-    @CsvSource(
-            {
-                    "MONGODB_LATEST"
-            }
-    )
-    public void testMongoDBDockerImage(DockerImage dockerImage) throws InterruptedException {
-        DockerUtility dockerUtility = new DockerUtility();
-        String containerName = "mongodb_container";
-        try {
-            // Create and run container
-            dockerUtility.createAndRunContainer(dockerImage, containerName, true);
+    @Override
+    public String getContainerName() {
+        return "mongo_db_container";
+    }
 
-            // Wait 20s for the MongoDB server to start up
-            Thread.sleep(20_000);
+    @Override
+    public long getStartupWaitTimeInMs() {
+        return 20_000;
+    }
 
-            // Test if the connection to the database is successful
-            Assertions.assertDoesNotThrow(() -> connectToMongoDBDatabase(dockerImage));
-        }
-        finally {
-            // Stop and remove container
-            dockerUtility.removeContainerIfExists(containerName);
-        }
+    @Override
+    public void testServiceInDockerContainer(DockerImage dockerImage) {
+        String password = dockerImage.getEnvironmentVariable("MONGO_INITDB_ROOT_PASSWORD");
+        Objects.requireNonNull(password);
+        MongoCredential credential = MongoCredential.createCredential("root", "admin", password.toCharArray());
+        MongoClient mongoClient = new MongoClient(
+            new ServerAddress("localhost", 27017),
+            Collections.singletonList(credential)
+        );
+        Assertions.assertEquals(
+            3,
+            mongoClient.listDatabaseNames()
+                .into(new ArrayList<>())
+                .size()
+        );
     }
 }

--- a/src/test/java/MySQLDockerImageTest.java
+++ b/src/test/java/MySQLDockerImageTest.java
@@ -1,63 +1,52 @@
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
-import java.sql.*;
-import java.util.Arrays;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.SQLException;
+import java.util.Objects;
 
-public class MySQLDockerImageTest {
+public class MySQLDockerImageTest extends ADockerImageTest {
 
     private final static Logger logger = LogManager.getLogger(MySQLDockerImageTest.class);
 
-    /**
-     * Connects to the specified MySQL database.
-     * @param dockerImage Docker image to retrieve all connection parameters from
-     * @throws SQLException Thrown when an issue occurs while connecting to the database
-     */
-    private void connectToMySQLDatabase(DockerImage dockerImage) throws SQLException {
-        String password = Arrays.stream(dockerImage.getEnvironmentVariables())
-                .filter(environmentVariable -> environmentVariable.startsWith("MYSQL_ROOT_PASSWORD="))
-                .map(environmentVariable -> environmentVariable.substring(20))
-                .findFirst()
-                .orElse("");
-
-        String connectionUrl =
-                "jdbc:mysql://127.0.0.1:3306";
-
-        Connection connection = DriverManager.getConnection(connectionUrl, "root", password);
-        Statement statement = connection.createStatement();
-        @SuppressWarnings("SqlNoDataSourceInspection")
-        String query = "show databases;";
-        logger.info("Executing query: " + query);
-        ResultSet resultSet = statement.executeQuery(query);
-        Assertions.assertEquals(0, resultSet.getFetchSize());
+    @Override
+    public DockerImage[] getDockerImages() {
+        return new DockerImage[] {
+            DockerImage.MYSQL_LATEST
+        };
     }
 
-    @ParameterizedTest
-    @CsvSource(
-            {
-                    "MYSQL_LATEST"
-            }
-    )
-    public void testMySQLDockerImage(DockerImage dockerImage) throws InterruptedException {
-        DockerUtility dockerUtility = new DockerUtility();
-        String containerName = "mysql_container";
+    @Override
+    public String getContainerName() {
+        return "mysql_container";
+    }
+
+    @Override
+    public long getStartupWaitTimeInMs() {
+        return 20_000;
+    }
+
+    @Override
+    public void testServiceInDockerContainer(DockerImage dockerImage) {
+        String password = dockerImage.getEnvironmentVariable("MYSQL_ROOT_PASSWORD");
+        Objects.requireNonNull(password);
+        String connectionUrl = "jdbc:mysql://127.0.0.1:3306";
 
         try {
-            // Create and run container
-            dockerUtility.createAndRunContainer(dockerImage, containerName, true);
-
-            // Wait 20s for the SQL server to start up
-            Thread.sleep(20_000);
-
-            // Test if the connection to the database is successful
-            Assertions.assertDoesNotThrow(() -> connectToMySQLDatabase(dockerImage));
-        }
-        finally {
-            // Stop and remove container
-            dockerUtility.removeContainerIfExists(containerName);
+            Connection connection = DriverManager.getConnection(connectionUrl, "root", password);
+            Statement statement = connection.createStatement();
+            @SuppressWarnings({"SqlNoDataSourceInspection", "SqlResolve"})
+            String query = "show databases;";
+            logger.info("Executing query: " + query);
+            ResultSet resultSet = statement.executeQuery(query);
+            Assertions.assertEquals(0, resultSet.getFetchSize());
+        } catch (SQLException e) {
+            logger.error("SQLException thrown while trying to connect to the DB.", e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/PostgreSQLDockerImageTest.java
+++ b/src/test/java/PostgreSQLDockerImageTest.java
@@ -1,69 +1,59 @@
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
-import java.sql.*;
-import java.util.Arrays;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.SQLException;
+import java.util.Objects;
 
-public class PostgreSQLDockerImageTest {
+public class PostgreSQLDockerImageTest extends ADockerImageTest {
 
     private final static Logger logger = LogManager.getLogger(PostgreSQLDockerImageTest.class);
 
-    /**
-     * Connects to the specified PostgreSQL database.
-     * @param dockerImage Docker image to retrieve all connection parameters from
-     * @throws SQLException Thrown when an issue occurs while connecting to the database
-     */
-    private void connectToPostgreSQLDatabase(DockerImage dockerImage) throws SQLException {
-        String password = Arrays.stream(dockerImage.getEnvironmentVariables())
-                .filter(environmentVariable -> environmentVariable.startsWith("POSTGRES_PASSWORD="))
-                .map(environmentVariable -> environmentVariable.substring(18))
-                .findFirst()
-                .orElse("");
-
-        String connectionUrl =
-                "jdbc:postgresql://127.0.0.1:5432/";
-
-        Connection connection = DriverManager.getConnection(connectionUrl, "postgres", password);
-
-        String query = "select datname from pg_database";
-        logger.info("Executing query: " + query + " against PostgreSQL");
-        Statement statement = connection.createStatement();
-        ResultSet resultSet = statement.executeQuery(query);
-        int actualRowCount = 0;
-        while (resultSet.next()) {
-            logger.info("Query Result from PostgreSQL: " + resultSet.getString(1));
-            actualRowCount++;
-        }
-        // PostgreSQL have three databases created by default: postgres, template0, and template1
-        Assertions.assertEquals(3, actualRowCount);
+    @Override
+    public DockerImage[] getDockerImages() {
+        return new DockerImage[] {
+            DockerImage.POSTGRESQL_LATEST
+        };
     }
 
-    @ParameterizedTest
-    @CsvSource(
-            {
-                    "POSTGRESQL_LATEST"
-            }
-    )
-    public void tesPostgreSQLDockerImage(DockerImage dockerImage) throws InterruptedException {
-        DockerUtility dockerUtility = new DockerUtility();
-        String containerName = "postgresql_container";
+    @Override
+    public String getContainerName() {
+        return "postgresql_container";
+    }
+
+    @Override
+    public long getStartupWaitTimeInMs() {
+        return 20_000;
+    }
+
+    @Override
+    public void testServiceInDockerContainer(DockerImage dockerImage) {
+        String password = dockerImage.getEnvironmentVariable("POSTGRES_PASSWORD");
+        Objects.requireNonNull(password);
+        String connectionUrl = "jdbc:postgresql://127.0.0.1:5432/";
 
         try {
-            // Create and run container
-            dockerUtility.createAndRunContainer(dockerImage, containerName, true);
+            Connection connection = DriverManager.getConnection(connectionUrl, "postgres", password);
 
-            // Wait 20s for the PostgresSQL server to start up
-            Thread.sleep(20_000);
-
-            // Test if the connection to the database is successful
-            Assertions.assertDoesNotThrow(() -> connectToPostgreSQLDatabase(dockerImage));
-        }
-        finally {
-            // Stop and remove container
-            dockerUtility.removeContainerIfExists(containerName);
+            @SuppressWarnings({"SqlResolve", "SqlNoDataSourceInspection"})
+            String query = "select datname from pg_database";
+            logger.info("Executing query: " + query + " against PostgreSQL");
+            Statement statement = connection.createStatement();
+            ResultSet resultSet = statement.executeQuery(query);
+            int actualRowCount = 0;
+            while (resultSet.next()) {
+                logger.info("Query Result from PostgreSQL: " + resultSet.getString(1));
+                actualRowCount++;
+            }
+            // PostgreSQL have three databases created by default: postgres, template0, and template1
+            Assertions.assertEquals(3, actualRowCount);
+        } catch (SQLException e) {
+            logger.error("SQLException thrown while trying to connect to the DB.", e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/src/test/java/SQLServerDockerImageTest.java
+++ b/src/test/java/SQLServerDockerImageTest.java
@@ -1,27 +1,41 @@
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
-import java.sql.*;
-import java.util.Arrays;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.sql.SQLException;
+import java.util.Objects;
 
-public class SQLServerDockerImageTest {
+public class SQLServerDockerImageTest extends ADockerImageTest {
 
     private final static Logger logger = LogManager.getLogger(SQLServerDockerImageTest.class);
 
-    /**
-     * Connects to the specified MSSQL database.
-     * @param dockerImage Docker image to retrieve all connection parameters from
-     * @throws SQLException Thrown when an issue occurs while connecting to the database
-     */
-    private void connectToMSSQLDatabase(DockerImage dockerImage) throws SQLException {
-        String password = Arrays.stream(dockerImage.getEnvironmentVariables())
-                .filter(environmentVariable -> environmentVariable.startsWith("SA_PASSWORD="))
-                .map(environmentVariable -> environmentVariable.substring(12))
-                .findFirst()
-                .orElse("");
+    @Override
+    public DockerImage[] getDockerImages() {
+        return new DockerImage[] {
+            DockerImage.MICROSOFT_SQL_SERVER_2019_LATEST,
+            DockerImage.MICROSOFT_SQL_SERVER_2019_CU6_UBUNTU_16_04,
+            DockerImage.MICROSOFT_SQL_SERVER_2017_LATEST,
+            DockerImage.MICROSOFT_SQL_SERVER_2017_CU21_UBUNTU_16_04
+        };
+    }
+
+    @Override
+    public String getContainerName() {
+        return "sql_server_container";
+    }
+
+    @Override
+    public long getStartupWaitTimeInMs() {
+        return 20_000;
+    }
+
+    @Override
+    public void testServiceInDockerContainer(DockerImage dockerImage) {
+        String password = dockerImage.getEnvironmentVariable("SA_PASSWORD");
+        Objects.requireNonNull(password);
 
         String connectionUrl = String.format(
                 "jdbc:sqlserver://127.0.0.1:1433;"
@@ -31,49 +45,22 @@ public class SQLServerDockerImageTest {
                         + "encrypt=true;"
                         + "trustServerCertificate=true;"
                         + "loginTimeout=30;",
-                        password
+                password
         );
 
-        Connection connection = DriverManager.getConnection(connectionUrl);
-        Statement statement = connection.createStatement();
-        @SuppressWarnings("SqlNoDataSourceInspection")
-        String query = "SELECT name, database_id, create_date FROM sys.databases ;";
-        logger.info("Executing query: " + query);
-        ResultSet resultSet = statement.executeQuery(query);
-        while (resultSet.next()) {
-            logger.info("Query Result: " + resultSet.getString(1) + ", " + resultSet.getString(2) + ", " + resultSet.getString(3));
-        }
-    }
-
-    @ParameterizedTest
-    @CsvSource(
-        {
-            "MICROSOFT_SQL_SERVER_2017_CU21_UBUNTU_16_04",
-            "MICROSOFT_SQL_SERVER_2017_LATEST",
-            "MICROSOFT_SQL_SERVER_2019_CU6_UBUNTU_16_04",
-            "MICROSOFT_SQL_SERVER_2019_LATEST"
-        }
-    )
-    public void testMSSQLDockerImage(DockerImage dockerImage) throws InterruptedException {
-        DockerUtility dockerUtility = new DockerUtility();
-        String containerName = "mssql_container";
-
         try {
-
-            logger.info("Starting container: " + containerName);
-
-            // Create and run container
-            dockerUtility.createAndRunContainer(dockerImage, containerName, true);
-
-            // Wait 20s for the SQL server to start up
-            Thread.sleep(20_000);
-
-            // Test if the connection to the database is successful
-            Assertions.assertDoesNotThrow(() -> connectToMSSQLDatabase(dockerImage));
-        }
-        finally {
-            // Stop and remove container
-            dockerUtility.removeContainerIfExists(containerName);
+            Connection connection = DriverManager.getConnection(connectionUrl);
+            Statement statement = connection.createStatement();
+            @SuppressWarnings("SqlNoDataSourceInspection")
+            String query = "SELECT name, database_id, create_date FROM sys.databases ;";
+            logger.info("Executing query: " + query);
+            ResultSet resultSet = statement.executeQuery(query);
+            while (resultSet.next()) {
+                logger.info("Query Result: " + resultSet.getString(1) + ", " + resultSet.getString(2) + ", " + resultSet.getString(3));
+            }
+        } catch (SQLException e) {
+            logger.error("SQLException thrown while trying to connect to the DB.", e);
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
Closes #22.
Previously all the container specific tests have duplicate deployment code.
Now, the common code has been pushed to an abstract class from which all the
container specific tests inherit.